### PR TITLE
switched from prometheus client to OTLP exporter 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ opentelemetry-api==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-instrumentation==0.45b0
 opentelemetry-instrumentation-flask==0.45b0
-opentelemetry-exporter-prometheus==0.45b0
-prometheus-client==0.20.0
+opentelemetry-exporter-otlp-proto-grpc==1.24.0

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ setup(
         'opentelemetry-sdk==1.24.0',
         'opentelemetry-instrumentation==0.45b0',
         'opentelemetry-instrumentation-flask==0.45b0',
-        'opentelemetry-exporter-prometheus==0.45b0',
-        'prometheus-client==0.20.0'
+        'opentelemetry-exporter-otlp-proto-grpc==1.24.0'
     ],
     entry_points='''
     [ckan.plugins]


### PR DESCRIPTION
We have a grafana agent ready in our monitoring kubernetes cluster, we don't need to start a new local webserver for scraping, so that will fix our bug